### PR TITLE
Change filter as tests

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,4 @@
 
 - name: restart memcached
   service: name=memcached state=restarted
-  when: not started_memcached|changed
+  when: not started_memcached is changed


### PR DESCRIPTION
Using tests as filters is deprecated. 
```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|changed` instead use `result is changed`. This feature will be removed
in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```